### PR TITLE
htmx v2

### DIFF
--- a/attrs.go
+++ b/attrs.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	g "github.com/maragudk/gomponents"
+	g "maragu.dev/gomponents"
 )
 
 func Boost(val bool) g.Node {

--- a/ext/client-side-templates.go
+++ b/ext/client-side-templates.go
@@ -1,8 +1,8 @@
 package ext
 
 import (
-	g "github.com/maragudk/gomponents"
-	"github.com/maragudk/gomponents/html"
+	g "maragu.dev/gomponents"
+	"maragu.dev/gomponents/html"
 )
 
 const (

--- a/ext/extensions.go
+++ b/ext/extensions.go
@@ -24,7 +24,7 @@ func ClassTools() g.Node {
 }
 
 func ServerSentEvents() g.Node {
-	return html.Script(html.Src("https://unpkg.com/htmx.org/dist/ext/sse.js"),
+	return html.Script(html.Src("https://unpkg.com/htmx-ext-sse@2.2.2/sse.js"),
 		g.Attr("crossorigin", "anonymous"),
 		g.Attr("defer"),
 	)

--- a/ext/extensions.go
+++ b/ext/extensions.go
@@ -1,8 +1,8 @@
 package ext
 
 import (
-	g "github.com/maragudk/gomponents"
-	"github.com/maragudk/gomponents/html"
+	g "maragu.dev/gomponents"
+	"maragu.dev/gomponents/html"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/flaticols/gomponents-htmx
 
 go 1.11
 
-require github.com/maragudk/gomponents v0.18.0
+require maragu.dev/gomponents v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/maragudk/gomponents v0.18.0 h1:EcdeRUWsWW6hK9ftnGAoyXR00SQWecCBxuXghQvdEcc=
-github.com/maragudk/gomponents v0.18.0/go.mod h1:0OdlqOoqxcwvhBFrp8wlKHnEXhNB7IVhb8GuARmd+tI=
+maragu.dev/gomponents v1.0.0 h1:eeLScjq4PqP1l+r5z/GC+xXZhLHXa6RWUWGW7gSfLh4=
+maragu.dev/gomponents v1.0.0/go.mod h1:oEDahza2gZoXDoDHhw8jBNgH+3UR5ni7Ur648HORydM=

--- a/gomponents-htmx.go
+++ b/gomponents-htmx.go
@@ -5,18 +5,14 @@ import (
 	"maragu.dev/gomponents/html"
 )
 
-// IncludeHtmx added the script tag with htmx
+// IncludeHtmx added the script tag with htmx.
+// Note: Using a CDN in production may not be ideal due to potential issues with
+// reliability, security, and performance. It might be preferable to self-host or bundle
+// the script for production deployments.
 func IncludeHtmx() g.Node {
-	return html.Script(html.Src("https://unpkg.com/htmx.org@1.7.0"),
-		g.Attr("integrity", "sha384-EzBXYPt0/T6gxNp0nuPtLkmRpmDBbjg6WmCUZRLXBBwYYmwAUxzlSGej0ARHX0Bo"),
-		g.Attr("crossorigin", "anonymous"),
-		g.Attr("defer"),
-	)
-}
-
-// IncludeHyperScript added the script tag with hyperscript
-func IncludeHyperScript() g.Node {
-	return html.Script(html.Src("https://unpkg.com/hyperscript.org@0.9.5"),
+	return html.Script(
+		html.Src("https://unpkg.com/htmx.org@2.0.4"),
+		g.Attr("integrity", "sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+"),
 		g.Attr("crossorigin", "anonymous"),
 		g.Attr("defer"),
 	)

--- a/gomponents-htmx.go
+++ b/gomponents-htmx.go
@@ -1,11 +1,11 @@
 package htmx
 
 import (
-	g "github.com/maragudk/gomponents"
-	"github.com/maragudk/gomponents/html"
+	g "maragu.dev/gomponents"
+	"maragu.dev/gomponents/html"
 )
 
-//IncludeHtmx added the script tag with htmx
+// IncludeHtmx added the script tag with htmx
 func IncludeHtmx() g.Node {
 	return html.Script(html.Src("https://unpkg.com/htmx.org@1.7.0"),
 		g.Attr("integrity", "sha384-EzBXYPt0/T6gxNp0nuPtLkmRpmDBbjg6WmCUZRLXBBwYYmwAUxzlSGej0ARHX0Bo"),
@@ -14,7 +14,7 @@ func IncludeHtmx() g.Node {
 	)
 }
 
-//IncludeHyperScript added the script tag with hyperscript
+// IncludeHyperScript added the script tag with hyperscript
 func IncludeHyperScript() g.Node {
 	return html.Script(html.Src("https://unpkg.com/hyperscript.org@0.9.5"),
 		g.Attr("crossorigin", "anonymous"),

--- a/http.go
+++ b/http.go
@@ -1,6 +1,6 @@
 package htmx
 
-import g "github.com/maragudk/gomponents"
+import g "maragu.dev/gomponents"
 
 func Get(path string) g.Node {
 	return g.Attr("hx-get", path)

--- a/sse.go
+++ b/sse.go
@@ -2,6 +2,23 @@ package htmx
 
 import g "maragu.dev/gomponents"
 
+// ServerSentEvents creates a group node with attributes to support Server-Sent Events for the specified connection path.
+// HTMX Docs: https://htmx.org/extensions/sse/
 func ServerSentEvents(path string) g.Node {
+	return g.Group{
+		g.Attr("hx-ext", "sse"),
+		g.Attr("sse-connect", path),
+	}
+}
+
+// ServerSentSwap sets up a server-sent event attribute with the provided message to enable SSE-based content swapping in the DOM.
+// HTMX Docs: https://htmx.org/extensions/sse/
+func ServerSentSwap(message string) g.Node {
+	return g.Attr("sse-swap", message)
+}
+
+// ServerSentConnect sets up a Server-Sent Events connection by specifying the URL path as an attribute. Returns a g.Node with the configured attribute.
+// HTMX Docs: https://htmx.org/extensions/sse/
+func ServerSentConnect(path string) g.Node {
 	return g.Attr("sse-connect", path)
 }

--- a/sse.go
+++ b/sse.go
@@ -1,6 +1,6 @@
 package htmx
 
-import g "github.com/maragudk/gomponents"
+import g "maragu.dev/gomponents"
 
 func ServerSentEvents(path string) g.Node {
 	return g.Attr("sse-connect", path)

--- a/swap.go
+++ b/swap.go
@@ -1,6 +1,6 @@
 package htmx
 
-import g "github.com/maragudk/gomponents"
+import g "maragu.dev/gomponents"
 
 const (
 	SwapInnerHTML   = "innerHTML"   //The default, replace the inner html of the target element

--- a/sync.go
+++ b/sync.go
@@ -1,6 +1,6 @@
 package htmx
 
-import g "github.com/maragudk/gomponents"
+import g "maragu.dev/gomponents"
 
 const (
 	SyncDrop       = "drop"

--- a/ws.go
+++ b/ws.go
@@ -1,14 +1,14 @@
 package htmx
 
 import (
-	g "github.com/maragudk/gomponents"
+	g "maragu.dev/gomponents"
 )
 
 func WebSockets(path string) g.Node {
 	return g.Attr("ws-connect", path)
 }
 
-//ConnectWebSockets wrap child to "ws-connect" component
+// ConnectWebSockets wrap child to "ws-connect" component
 func ConnectWebSockets(path string, children ...g.Node) g.Node {
 	children = append(children, Ext("ws"))
 	children = append(children, WebSockets(path))


### PR DESCRIPTION
This pull request includes various changes to update the import paths and improve the handling of external scripts and Server-Sent Events (SSE) in the `gomponents-htmx` package. The most important changes include updating the import paths from `github.com/maragudk/gomponents` to `maragu.dev/gomponents`, modifying the script URLs for `htmx` and `sse`, and adding new functions to support SSE.

### Import Path Updates:
* Updated import paths from `github.com/maragudk/gomponents` to `maragu.dev/gomponents` in multiple files (`attrs.go`, `client-side-templates.go`, `extensions.go`, `gomponents-htmx.go`, `http.go`, `swap.go`, `sync.go`, `ws.go`). [[1]](diffhunk://#diff-294cb6aa0a7c41cb4e7fc0f51963be9f20b5b75712c4c4eb84baf27627169cd5L7-R7) [[2]](diffhunk://#diff-3dfc81b6830f59f477d77e98d726cef5f49a03f5ec62c4de975888470cf256a5L4-R5) [[3]](diffhunk://#diff-bb55d338af16d4a6135f34bff2eead79d6dc7e05da052d94c603ca89dda6f758L4-R5) [[4]](diffhunk://#diff-0208f4085334457a618b3bb2de901194cc3af15846bb81ec5d4ba18770e95710L4-R15) [[5]](diffhunk://#diff-6971e2713fe98b79ea18e9748bf68928f6ebcd4d93e7a27f10e7472ce6d78a48L3-R3) [[6]](diffhunk://#diff-b8400ee143c156ba152e6e54f3f37855db91dad69e06b05120e11fa4e0f97da8L3-R3) [[7]](diffhunk://#diff-d41679517cfd690d16b66f15bf8af782a50081525eb9df1af20ccc8f10d092aeL3-R3) [[8]](diffhunk://#diff-343a1e9db36f975ae7f62a6978b5ac3ff8583cf796bdfd5b4105095d74187a93L4-R4)

### Script URL Modifications:
* Updated the script URL for `htmx` in `IncludeHtmx` function to use version `2.0.4` and added a note about potential issues with using a CDN in production (`gomponents-htmx.go`).
* Updated the script URL for `sse` in `ServerSentEvents` function to use version `2.2.2` (`extensions.go`).

### Server-Sent Events (SSE) Enhancements:
* Added new functions `ServerSentEvents`, `ServerSentSwap`, and `ServerSentConnect` to support SSE attributes and connections (`sse.go`).

### Dependency Update:
* Updated the dependency version for `gomponents` in `go.mod` from `v0.18.0` to `v1.0.0`.This pull request includes updates to the import paths for the `gomponents` library across multiple files. The changes ensure that the project uses the new domain for the `gomponents` library.

### Library Import Path Updates:

* [`attrs.go`](diffhunk://#diff-294cb6aa0a7c41cb4e7fc0f51963be9f20b5b75712c4c4eb84baf27627169cd5L7-R7): Updated the import path for `gomponents` to `maragu.dev/gomponents`.
* [`ext/client-side-templates.go`](diffhunk://#diff-3dfc81b6830f59f477d77e98d726cef5f49a03f5ec62c4de975888470cf256a5L4-R5): Changed the import paths for `gomponents` and `gomponents/html` to the new domain `maragu.dev/gomponents` and `maragu.dev/gomponents/html`.
* [`ext/extensions.go`](diffhunk://#diff-bb55d338af16d4a6135f34bff2eead79d6dc7e05da052d94c603ca89dda6f758L4-R5): Updated the import paths for `gomponents` and `gomponents/html` to the new domain `maragu.dev/gomponents` and `maragu.dev/gomponents/html`.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L5-R5): Modified the module requirement for `gomponents` to `maragu.dev/gomponents v1.0.0`.
* [`gomponents-htmx.go`](diffhunk://#diff-0208f4085334457a618b3bb2de901194cc3af15846bb81ec5d4ba18770e95710L4-R5): Updated the import paths for `gomponents` and `gomponents/html` to `maragu.dev/gomponents` and `maragu.dev/gomponents/html`.
* [`http.go`](diffhunk://#diff-6971e2713fe98b79ea18e9748bf68928f6ebcd4d93e7a27f10e7472ce6d78a48L3-R3): Changed the import path for `gomponents` to `maragu.dev/gomponents`.
* [`sse.go`](diffhunk://#diff-3444b98acd8f09dd3102ce95d46f33bc67672604c03161af2115cad0895e26f3L3-R3): Updated the import path for `gomponents` to `maragu.dev/gomponents`.
* [`swap.go`](diffhunk://#diff-b8400ee143c156ba152e6e54f3f37855db91dad69e06b05120e11fa4e0f97da8L3-R3): Changed the import path for `gomponents` to `maragu.dev/gomponents`.
* [`sync.go`](diffhunk://#diff-d41679517cfd690d16b66f15bf8af782a50081525eb9df1af20ccc8f10d092aeL3-R3): Updated the import path for `gomponents` to `maragu.dev/gomponents`.
* [`ws.go`](diffhunk://#diff-343a1e9db36f975ae7f62a6978b5ac3ff8583cf796bdfd5b4105095d74187a93L4-R4): Changed the import path for `gomponents` to `maragu.dev/gomponents`.